### PR TITLE
Ensure action decider responses are valid JSON

### DIFF
--- a/src/agent_system/decider.py
+++ b/src/agent_system/decider.py
@@ -101,7 +101,8 @@ The agent can only execute actions through registered tools.
             [
                 Message(role="system", content=self._SYSTEM_PROMPT),
                 Message(role="user", content=json.dumps(user_prompt, ensure_ascii=False)),
-            ]
+            ],
+            response_format={"type": "json_object"},
         )
         try:
             payload = json.loads(response)

--- a/src/agent_system/llm.py
+++ b/src/agent_system/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
 
 from openai import OpenAI
 
@@ -39,16 +39,24 @@ class LLMClient:
 
         return self._config.model
 
-    def chat(self, messages: Sequence[Message]) -> str:
+    def chat(
+        self,
+        messages: Sequence[Message],
+        *,
+        response_format: Mapping[str, object] | None = None,
+    ) -> str:
         """Execute a chat completion request and return the response text."""
 
         payload = [{"role": msg.role, "content": msg.content} for msg in messages]
-        response = self._client.chat.completions.create(
-            model=self._config.model,
-            messages=payload,
-            timeout=self._config.request_timeout,
+        request_args: MutableMapping[str, Any] = {
+            "model": self._config.model,
+            "messages": payload,
+            "timeout": self._config.request_timeout,
             **self._config.extra,
-        )
+        }
+        if response_format is not None:
+            request_args["response_format"] = dict(response_format)
+        response = self._client.chat.completions.create(**request_args)
         choice = response.choices[0]
         return (choice.message.content or "").strip()
 


### PR DESCRIPTION
## Summary
- allow the LLM client to optionally request structured JSON responses from chat completions
- require the action decider to use the JSON response format when requesting decisions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78cc3cae48331a5631d5f62b0f95f