### PR TITLE
Use JSON schema response format for decider

### DIFF
--- a/src/agent_system/decider.py
+++ b/src/agent_system/decider.py
@@ -54,6 +54,42 @@ JSON schema:
 The agent can only execute actions through registered tools.
 """
 
+    _RESPONSE_FORMAT = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "action_decision",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "thought": {"type": "string"},
+                    "action": {
+                        "type": "string",
+                        "enum": ["use_tool", "think", "create_tool"],
+                    },
+                    "tool_name": {"type": ["string", "null"]},
+                    "arguments": {"type": "object"},
+                    "new_tool": {
+                        "anyOf": [
+                            {"type": "null"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "purpose": {"type": "string"},
+                                    "specification": {"type": "string"},
+                                },
+                                "required": ["name", "purpose", "specification"],
+                                "additionalProperties": False,
+                            },
+                        ]
+                    },
+                },
+                "required": ["thought", "action", "arguments"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
 
     def __init__(self, llm: LLMClient, *, require_reasoning: bool = True) -> None:
         """Create a decider.
@@ -101,7 +137,8 @@ The agent can only execute actions through registered tools.
             [
                 Message(role="system", content=self._SYSTEM_PROMPT),
                 Message(role="user", content=json.dumps(user_prompt, ensure_ascii=False)),
-            ]
+            ],
+            response_format=self._RESPONSE_FORMAT,
         )
         try:
             payload = json.loads(response)

--- a/src/agent_system/llm.py
+++ b/src/agent_system/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
 
 from openai import OpenAI
 
@@ -39,16 +39,24 @@ class LLMClient:
 
         return self._config.model
 
-    def chat(self, messages: Sequence[Message]) -> str:
+    def chat(
+        self,
+        messages: Sequence[Message],
+        *,
+        response_format: Mapping[str, object] | None = None,
+    ) -> str:
         """Execute a chat completion request and return the response text."""
 
         payload = [{"role": msg.role, "content": msg.content} for msg in messages]
-        response = self._client.chat.completions.create(
-            model=self._config.model,
-            messages=payload,
-            timeout=self._config.request_timeout,
+        request_args: MutableMapping[str, Any] = {
+            "model": self._config.model,
+            "messages": payload,
+            "timeout": self._config.request_timeout,
             **self._config.extra,
-        )
+        }
+        if response_format is not None:
+            request_args["response_format"] = dict(response_format)
+        response = self._client.chat.completions.create(**request_args)
         choice = response.choices[0]
         return (choice.message.content or "").strip()
 


### PR DESCRIPTION
## Summary
- define an OpenAI JSON schema response format that matches the decider contract
- update the action decider to request the schema so completions stay within API constraints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78cc3cae48331a5631d5f62b0f95f