### PR TITLE
Fix ActionDecider response format to use JSON schema

### DIFF
--- a/src/agent_system/decider.py
+++ b/src/agent_system/decider.py
@@ -102,7 +102,39 @@ The agent can only execute actions through registered tools.
                 Message(role="system", content=self._SYSTEM_PROMPT),
                 Message(role="user", content=json.dumps(user_prompt, ensure_ascii=False)),
             ],
-            response_format={"type": "json_object"},
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "action_decision",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "thought": {"type": "string"},
+                            "action": {
+                                "type": "string",
+                                "enum": ["use_tool", "think", "create_tool"],
+                            },
+                            "tool_name": {"type": ["string", "null"]},
+                            "arguments": {"type": "object"},
+                            "new_tool": {
+                                "anyOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "purpose": {"type": "string"},
+                                            "specification": {"type": "string"},
+                                        },
+                                        "required": ["name", "purpose", "specification"],
+                                    },
+                                ]
+                            },
+                        },
+                        "required": ["thought", "action", "arguments"],
+                    },
+                },
+            },
         )
         try:
             payload = json.loads(response)


### PR DESCRIPTION
## Summary
- update the ActionDecider to request responses using the json_schema response format
- define a schema that matches the required action decision payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d791a71fac8331837ad72563e77fab