### PR TITLE
Enforce tool requirements in action decider schema

### DIFF
--- a/src/agent_system/decider.py
+++ b/src/agent_system/decider.py
@@ -132,6 +132,36 @@ The agent can only execute actions through registered tools.
                             },
                         },
                         "required": ["thought", "action", "arguments"],
+                        "allOf": [
+                            {
+                                "if": {"properties": {"action": {"const": "use_tool"}}},
+                                "then": {
+                                    "properties": {"tool_name": {"type": "string"}},
+                                    "required": ["tool_name"],
+                                },
+                            },
+                            {
+                                "if": {"properties": {"action": {"const": "create_tool"}}},
+                                "then": {
+                                    "properties": {
+                                        "new_tool": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "purpose": {"type": "string"},
+                                                "specification": {"type": "string"},
+                                            },
+                                            "required": [
+                                                "name",
+                                                "purpose",
+                                                "specification",
+                                            ],
+                                        }
+                                    },
+                                    "required": ["new_tool"],
+                                },
+                            },
+                        ],
                     },
                 },
             },


### PR DESCRIPTION
## Summary
- enforce schema constraints so tool actions must include a tool name
- require fully specified new tool details when requesting tool creation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d79310a3ec8331956a880ecb8abc55