### PR TITLE
Add retries for invalid action decisions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ Runtime settings live in `AgentConfig` (`src/agent_system/config.py`). Override 
 - **LLMConfig** – Model name, API key/base URL, timeout, and additional OpenAI parameters.
 - **PlanningConfig** – Maximum plan steps and whether the decider must always provide reasoning (`require_reasoning`).
 - **ToolingConfig** – Generated tools path and `auto_persist` flag controlling persistence.
+- **AgentConfig.max_decision_attempts** – Number of times the orchestrator will retry the
+  action-selection step when the model returns an invalid decision.
 
 ## Tool persistence & custom tools
 

--- a/src/agent_system/config.py
+++ b/src/agent_system/config.py
@@ -50,3 +50,4 @@ class AgentConfig:
     planning: PlanningConfig = field(default_factory=PlanningConfig)
     tooling: ToolingConfig = field(default_factory=ToolingConfig)
     verbose: bool = True
+    max_decision_attempts: int = 2

--- a/src/agent_system/orchestrator.py
+++ b/src/agent_system/orchestrator.py
@@ -66,16 +66,30 @@ class AgentOrchestrator:
 
         plan = self._planner.create_plan(goal, context=context)
         result = AgentRunResult(plan=plan)
+        max_attempts = max(1, self._config.max_decision_attempts)
         for step in plan.steps:
             tools = self._tool_manager.available_tools()
-            try:
-                decision = self._decider.decide(step, tools, context=context)
-            except DecisionError as exc:
+            decision: ActionDecision | None = None
+            last_error: str | None = None
+            decision_context = context
+            for attempt in range(max_attempts):
+                try:
+                    decision = self._decider.decide(step, tools, context=decision_context)
+                    break
+                except DecisionError as exc:
+                    last_error = str(exc)
+                    if attempt + 1 < max_attempts:
+                        base_context = (context or "").strip()
+                        retry_hint = f"Previous decision error: {last_error}"
+                        decision_context = (
+                            f"{base_context}\n{retry_hint}" if base_context else retry_hint
+                        )
+            if decision is None:
                 result.steps.append(
                     StepLog(
                         step_description=step,
                         decision=ActionDecision("", "think", None, {}, None),
-                        error=str(exc),
+                        error=last_error,
                     )
                 )
                 continue


### PR DESCRIPTION
## Summary
- add a configurable `max_decision_attempts` option to the agent configuration
- retry invalid action decisions with contextual guidance before logging an error
- document the new runtime setting in the README

## Testing
- python -m compileall src streamlit_app.py main.py example_mortgage_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d79409063883319151cf0dfdf342f3