### PR TITLE
Fix web search tool and adopt Harmony responses

### DIFF
--- a/src/agent_system/llm.py
+++ b/src/agent_system/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, MutableMapping, Sequence
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
 
 from openai import OpenAI
 
@@ -47,18 +47,46 @@ class LLMClient:
     ) -> str:
         """Execute a chat completion request and return the response text."""
 
-        payload = [{"role": msg.role, "content": msg.content} for msg in messages]
+        payload = [
+            {
+                "role": msg.role,
+                "content": [{"type": "text", "text": msg.content}],
+            }
+            for msg in messages
+        ]
         request_args: MutableMapping[str, Any] = {
             "model": self._config.model,
-            "messages": payload,
+            "input": payload,
             "timeout": self._config.request_timeout,
             **self._config.extra,
         }
         if response_format is not None:
             request_args["response_format"] = dict(response_format)
-        response = self._client.chat.completions.create(**request_args)
-        choice = response.choices[0]
-        return (choice.message.content or "").strip()
+        response = self._client.responses.create(**request_args)
+        output_text = getattr(response, "output_text", None)
+        if output_text:
+            return output_text.strip()
+        text_chunks = list(self._extract_text_chunks(response))
+        if text_chunks:
+            return "".join(text_chunks).strip()
+        return ""
+
+    def _extract_text_chunks(self, response: Any) -> Iterable[str]:
+        """Yield text segments from a Harmony response object."""
+
+        output = getattr(response, "output", None)
+        if not output:
+            return
+        for item in output:
+            contents = getattr(item, "content", None)
+            if not contents:
+                continue
+            for content in contents:
+                content_type = getattr(content, "type", None)
+                if content_type in {"output_text", "text"}:
+                    text = getattr(content, "text", None)
+                    if text:
+                        yield text
 
     def simple_completion(self, system_prompt: str, user_prompt: str) -> str:
         """Small helper when only a system and user prompt are required."""

--- a/src/agent_system/tools/web.py
+++ b/src/agent_system/tools/web.py
@@ -10,6 +10,13 @@ from urllib.parse import parse_qs, unquote, urljoin, urlparse
 
 import requests
 
+_DDG_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    )
+}
+
 try:  # pragma: no cover - optional dependency
     from duckduckgo_search import DDGS  # type: ignore
 except Exception:  # pragma: no cover - fallback when package missing
@@ -60,14 +67,16 @@ def fetch_url(url: str, timeout: int = 15) -> str:
 
     if not url:
         raise ValueError("URL must be provided.")
-    response = requests.get(url, timeout=timeout)
+    response = requests.get(url, timeout=timeout, headers=_DDG_HEADERS)
     response.raise_for_status()
     return response.text
 
 
 def _duckduckgo_html_fallback(query: str, max_results: int) -> Iterable[SearchResult]:
     params = {"q": query, "kl": "us-en"}
-    response = requests.get("https://duckduckgo.com/html", params=params, timeout=15)
+    response = requests.get(
+        "https://duckduckgo.com/html", params=params, timeout=15, headers=_DDG_HEADERS
+    )
     response.raise_for_status()
     html_text = response.text
     pattern = re.compile(
@@ -107,7 +116,9 @@ def _duckduckgo_html_fallback(query: str, max_results: int) -> Iterable[SearchRe
 
 def _duckduckgo_instant_answer_fallback(query: str, max_results: int) -> Iterable[SearchResult]:
     params = {"q": query, "format": "json", "no_redirect": "1", "no_html": "1"}
-    response = requests.get("https://api.duckduckgo.com/", params=params, timeout=15)
+    response = requests.get(
+        "https://api.duckduckgo.com/", params=params, timeout=15, headers=_DDG_HEADERS
+    )
     response.raise_for_status()
     data = response.json()
     results: List[SearchResult] = []


### PR DESCRIPTION
## Summary
- switch the LLM client to the OpenAI Responses API with Harmony-compatible message formatting
- add robust text extraction helpers so agent replies are returned even when output chunks differ
- send a modern User-Agent header on DuckDuckGo and other HTTP requests to restore the web search tool

## Testing
- python -m compileall src/agent_system/llm.py src/agent_system/tools/web.py

------
https://chatgpt.com/codex/tasks/task_e_68d796a5a5688331810d9df984002743